### PR TITLE
fix(bin): handle userland babel.config.js

### DIFF
--- a/packages/navi-scripts/bin/navi-scripts.js
+++ b/packages/navi-scripts/bin/navi-scripts.js
@@ -14,6 +14,7 @@ let defaultHost = process.platform === 'win32'
 // recent JavaScript features.
 require("@babel/register")({
   babelrc: false,
+  configFile: false,
   presets: [
     [
       "@babel/preset-env",


### PR DESCRIPTION
Currently, custom config detection wont work if babel.config.js is being used by the user.