### PR TITLE
Change the import Link in pages reference example in readme to be Nav…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ But what about the `/reference` page? It's not returning an element or component
 ```js
 // pages/reference.js
 import * as React from 'react'
-import { Link } from 'react-navi'
+import { NavLink } from 'react-navi'
 
 export default function Reference() {
   return (


### PR DESCRIPTION
…Link

Updating the readme under:// pages/reference.js

to be

`import { NavLink } from 'react-navi'`

replacing 

`import { Link } from 'react-nav'`

as Link appears to not be a part of react-navi