### PR TITLE
throw error when path is not a function

### DIFF
--- a/packages/navi/src/Switch.ts
+++ b/packages/navi/src/Switch.ts
@@ -27,6 +27,12 @@ import {
   ResolvableNode,
   NodeMatcherOptions,
 } from './Node'
+// import {
+//   PageMatcher
+// } from './Page'
+// import {
+//   RedirectMatcher
+// } from './Redirect'
 
 export type SwitchPaths<Context extends object> = {
   [pattern: string]: MaybeResolvableNode<Context>
@@ -246,6 +252,28 @@ export function createSwitch<Context extends object, Meta extends object, Conten
   }
 
   let patterns = Object.keys(options.paths)
+  
+  // initial idea was this, but several tests failed as they are raw functions
+  // which take an env => any
+  /*
+  let notInstanceOf = x => y => !(x instanceof y)
+  let invalidPaths = patterns.filter(pattern => {
+    let proto = options.paths[pattern].prototype
+    const not = notInstanceOf(proto)
+    return not(NodeMatcher) &&
+      not(PageMatcher) &&
+      not(SwitchMatcher) &&
+      not(RedirectMatcher)
+  }
+  */
+
+  let invalidPaths = patterns.filter(
+    pattern => !options.paths[pattern].prototype
+  )
+  if (invalidPaths.length > 0) {
+    let singular = invalidPaths.length === 1
+    throw new TypeError(`The given ${singular ? 'path' : 'paths'}: ${invalidPaths.join(', ')} ${singular ? 'is' : 'are'} invalid. Path should be an instance of Switch, Page, Redirect, Context or a function. See https://frontarm.com/navi/reference/declarations/#declaring-pages`)
+  }
 
   // Wildcards in PatternMap objects are null (\0) characters, so they'll
   // always be sorted to the top. As such, by sorting the patterns, the

--- a/packages/navi/src/Switch.ts
+++ b/packages/navi/src/Switch.ts
@@ -27,12 +27,6 @@ import {
   ResolvableNode,
   NodeMatcherOptions,
 } from './Node'
-// import {
-//   PageMatcher
-// } from './Page'
-// import {
-//   RedirectMatcher
-// } from './Redirect'
 
 export type SwitchPaths<Context extends object> = {
   [pattern: string]: MaybeResolvableNode<Context>
@@ -253,20 +247,6 @@ export function createSwitch<Context extends object, Meta extends object, Conten
 
   let patterns = Object.keys(options.paths)
   
-  // initial idea was this, but several tests failed as they are raw functions
-  // which take an env => any
-  /*
-  let notInstanceOf = x => y => !(x instanceof y)
-  let invalidPaths = patterns.filter(pattern => {
-    let proto = options.paths[pattern].prototype
-    const not = notInstanceOf(proto)
-    return not(NodeMatcher) &&
-      not(PageMatcher) &&
-      not(SwitchMatcher) &&
-      not(RedirectMatcher)
-  }
-  */
-
   let invalidPaths = patterns.filter(
     pattern => !options.paths[pattern].prototype
   )

--- a/packages/navi/test/Switch.test.ts
+++ b/packages/navi/test/Switch.test.ts
@@ -17,20 +17,6 @@ describe("Switch", () => {
     expect(route.url.pathname).toBe('/to/')
     expect(route.url.query.from).toBe('/from')
   })
-  test("Fails on non-function as path", async () => {
-    try {
-      await createMemoryNavigation({
-        url: '/from',
-        pages: createSwitch({
-          paths: {
-            '/fail': {title: 'this fails'}
-          }
-        })
-      })
-    } catch (e) {
-      expect(e.message).toMatch('The given path: /fail is invalid. Path should be an instance of Switch, Page, Redirect, Context or a function. See https://frontarm.com/navi/reference/declarations/#declaring-pages');
-    }
-  })
   test("Fails on multiple non-functions as paths", async () => {
     try {
       await createMemoryNavigation({
@@ -43,7 +29,8 @@ describe("Switch", () => {
         })
       })
     } catch (e) {
-      expect(e.message).toMatch('The given paths: /fail, /this-also-fails are invalid. Path should be an instance of Switch, Page, Redirect, Context or a function. See https://frontarm.com/navi/reference/declarations/#declaring-pages');
+      expect(e.message.indexOf('/this-also-fails') > -1).toBeTruthy()
+      expect(e.message.indexOf('/fail') > -1).toBeTruthy()
     }
   })
 })

--- a/packages/navi/test/Switch.test.ts
+++ b/packages/navi/test/Switch.test.ts
@@ -17,4 +17,33 @@ describe("Switch", () => {
     expect(route.url.pathname).toBe('/to/')
     expect(route.url.query.from).toBe('/from')
   })
+  test("Fails on non-function as path", async () => {
+    try {
+      await createMemoryNavigation({
+        url: '/from',
+        pages: createSwitch({
+          paths: {
+            '/fail': {title: 'this fails'}
+          }
+        })
+      })
+    } catch (e) {
+      expect(e.message).toMatch('The given path: /fail is invalid. Path should be an instance of Switch, Page, Redirect, Context or a function. See https://frontarm.com/navi/reference/declarations/#declaring-pages');
+    }
+  })
+  test("Fails on multiple non-functions as paths", async () => {
+    try {
+      await createMemoryNavigation({
+        url: '/from',
+        pages: createSwitch({
+          paths: {
+            '/fail': {title: 'this fails'}
+            '/this-also-fails': {title: 'this too'}
+          }
+        })
+      })
+    } catch (e) {
+      expect(e.message).toMatch('The given paths: /fail, /this-also-fails are invalid. Path should be an instance of Switch, Page, Redirect, Context or a function. See https://frontarm.com/navi/reference/declarations/#declaring-pages');
+    }
+  })
 })


### PR DESCRIPTION
Attempts to fix: https://github.com/frontarm/navi/issues/40

Initial idea did specific `instanceof` matching, however several tests seem to have paths which take `env` and then return some Switch / Redirect / Page / Context, so I changed the test to simply see if the provided path has a prototype.

Also this version throws a TypeError, but potentially it would be better to `console.warn` instead; as there are both precedents already in the function I elected to throw, but I don't feel strongly.

Also not married to the error text itself, feel free to suggest anything similar.