### PR TITLE
Fix tsc incompatibility

### DIFF
--- a/packages/react-navi/src/Link.tsx
+++ b/packages/react-navi/src/Link.tsx
@@ -22,7 +22,7 @@ export interface UseLinkPropsOptions {
   onMouseEnter?: React.MouseEventHandler<HTMLAnchorElement>
 }
 
-function isExternalHref(href) {
+function isExternalHref(href: string | Partial<URLDescriptor>) {
   // If this is an external link, return undefined so that the native
   // response will be used.
   return (
@@ -43,6 +43,7 @@ function getLinkURL(
     }
     return createURLDescriptor(href)
   }
+  return undefined
 }
 
 /**
@@ -161,7 +162,7 @@ export const useLinkProps = ({
         navigation
       ) {
         hasPrefetched = true
-        navigation.prefetch(memoizedLinkURL).catch(e => {
+        navigation.prefetch(memoizedLinkURL).catch(_e => {
           console.warn(
             `A <Link> tried to prefetch "${
               memoizedLinkURL!.pathname


### PR DESCRIPTION
I run `tsc --noEmit` during CI to ensure that my app's types don't have any errors. It has now started catching these, (even though I have `node_modules` excluded in my tsconfig.json) and they're easy fixes.

> $ tsc --noEmit -p .
> 
> node_modules/react-navi/src/Link.tsx:25:25 - error TS7006: Parameter 'href' implicitly has an 'any' type.
> 
> 25 function isExternalHref(href) {
>                            ~~~~
> 
> node_modules/react-navi/src/Link.tsx:38:4 - error TS7030: Not all code paths return a value.
> 
> 38 ): undefined | URLDescriptor {
>       ~~~~~~~~~~~~~~~~~~~~~~~~~
> 
> node_modules/react-navi/src/Link.tsx:164:52 - error TS6133: 'e' is declared but its value is never read.
> 
> 164         navigation.prefetch(memoizedLinkURL).catch(e => {
>                                                        ~
> 