### PR TITLE
Fix styles not being applied to Link. Clean up className logic as well.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ NOTES.md
 dist
 navi-website
 packages/navi-website
+.idea

--- a/packages/react-navi/src/Link.tsx
+++ b/packages/react-navi/src/Link.tsx
@@ -271,9 +271,9 @@ export const Link: React.FunctionComponent<LinkProps> = React.forwardRef(
   (props: LinkProps, anchorRef: React.Ref<HTMLAnchorElement>) => {
     let {
       active,
-      activeClassName,
-      activeStyle,
-      className,
+      activeClassName = '',
+      activeStyle = {},
+      className = '',
       disabled,
       exact,
       hashScrollBehavior,
@@ -282,7 +282,7 @@ export const Link: React.FunctionComponent<LinkProps> = React.forwardRef(
       onMouseEnter: onMouseEnterProp,
       prefetch,
       state,
-      style,
+      style = {},
       ...rest
     } = props
 
@@ -303,12 +303,11 @@ export const Link: React.FunctionComponent<LinkProps> = React.forwardRef(
     return (
       <a
         ref={anchorRef}
-        className={`${className || ''} ${(active && activeClassName) || ''}`}
-        style={
-          style && activeStyle
-            ? Object.assign({}, style, active ? activeStyle : {})
-            : undefined
-        }
+        className={`${className} ${(active ? activeClassName : '')}`}
+        style={{
+          ...style,
+          ...(active ? activeStyle : {})
+        }}
         {...rest}
         {...linkProps}
         // Don't handle events on links with a `target` prop.


### PR DESCRIPTION
Fixes #184. Let me know if you're happy with the the changes, feel free to be super nit picky, will adjust. Object destructuring with default values seemed simpler to me than doing `Object.assign`.

Also cleaned up the className side with default values.