### PR TITLE
Removed usage of non existing types, SFC -> FC

### DIFF
--- a/packages/react-navi/src/NotFoundBoundary.tsx
+++ b/packages/react-navi/src/NotFoundBoundary.tsx
@@ -10,7 +10,7 @@ export namespace NotFoundBoundary {
   export type Props = NotFoundBoundaryProps
 }
 
-export const NotFoundBoundary: React.SFC<NotFoundBoundaryProps> = function ErrorBoundary(props: NotFoundBoundaryProps) {
+export const NotFoundBoundary: React.FC<NotFoundBoundaryProps> = function ErrorBoundary(props: NotFoundBoundaryProps) {
   return (
     <NaviContext.Consumer>
       {context => <InnerNotFoundBoundary context={context} {...props} />}


### PR DESCRIPTION

Changes proposed in this PR:
- Switched component type for `NotFoundBoundary` from SFC into FC to match React 18 types

In React 18 SFC does not exist.
